### PR TITLE
fix: QR scanning doesn't work when navigating back

### DIFF
--- a/app/src/screens/ProveFlow/ViewFinder.tsx
+++ b/app/src/screens/ProveFlow/ViewFinder.tsx
@@ -1,7 +1,11 @@
 import React, { useCallback, useState } from 'react';
 import { StyleSheet } from 'react-native';
 
-import { useFocusEffect, useIsFocused, useNavigation } from '@react-navigation/native';
+import {
+  useFocusEffect,
+  useIsFocused,
+  useNavigation,
+} from '@react-navigation/native';
 import LottieView from 'lottie-react-native';
 import { View, XStack, YStack } from 'tamagui';
 
@@ -48,7 +52,7 @@ const QRCodeViewFinderScreen: React.FC<QRCodeViewFinderScreenProps> = ({}) => {
   useFocusEffect(
     useCallback(() => {
       setDoneScanningQR(false);
-    }, [])
+    }, []),
   );
 
   const onQRData = useCallback<QRCodeScannerViewProps['onQRData']>(


### PR DESCRIPTION
This PR addresses a bug where scanning a QR code again was not possible when hitting back button from next screen.