### PR TITLE
Hide home activity button for now

### DIFF
--- a/app/src/components/HomeNavBar.tsx
+++ b/app/src/components/HomeNavBar.tsx
@@ -29,7 +29,14 @@ const HomeNavBar = (props: NativeStackHeaderProps) => {
             }
           />
         }
-        onPress={() => props.navigation.navigate('Activity')}
+        // disable icon click for now
+        onPress={() => {
+          // props.navigation.navigate('Activity');
+          return false;
+        }}
+        style={{
+          opacity: 0,
+        }}
       />
       <NavBar.Title size="large" color={white}>
         {props.options.title}


### PR DESCRIPTION
Hide activity button on home screen

Jon request:
<img width="338" alt="Screenshot 2025-02-13 at 8 40 43 PM" src="https://github.com/user-attachments/assets/64d9ce36-caf0-4861-8499-d7a12b16a921" />

Implementation:
![update](https://github.com/user-attachments/assets/3f9aa22e-d6e7-4dd9-9dad-580c5ac5719d)
