### PR TITLE
redirectable links

### DIFF
--- a/app/src/consts/links.ts
+++ b/app/src/consts/links.ts
@@ -10,9 +10,7 @@ export const telegramUrl = 'https://self.xyz/telegram';
 export const gitHubUrl = 'https://github.com/selfxyz/self';
 
 // TODO real link
-export const appStoreUrl =
-  'https://self.xyz/app-store';
+export const appStoreUrl = 'https://self.xyz/app-store';
 
 // TODO real link
-export const playStoreUrl =
-  'https://self.xyz/play-store';
+export const playStoreUrl = 'https://self.xyz/play-store';


### PR DESCRIPTION
use placeholders that can be redirected instead off fake links