### PR TITLE
add new instance to build_cpp

### DIFF
--- a/circuits/scripts/build/build_cpp.sh
+++ b/circuits/scripts/build/build_cpp.sh
@@ -21,6 +21,7 @@ REGISTER_CIRCUITS=(
     "register_sha256_sha256_sha256_rsa_65537_4096:true"
     "register_sha256_sha256_sha256_rsapss_3_32_4096:false"
     "register_sha256_sha256_sha256_rsapss_65537_4096:false"
+    "register_sha384_sha384_sha384_rsapss_65537_48_2048:false"
     "register_sha384_sha384_sha384_ecdsa_brainpoolP256r1:false"
     "register_sha384_sha384_sha384_ecdsa_brainpoolP384r1:false"
     "register_sha384_sha384_sha384_ecdsa_secp384r1:false"


### PR DESCRIPTION
@ayman we also added back `register_sha1_sha1_sha1_ecdsa_brainpoolP224r1.circom`, which was in the script as false before, but you removed in https://github.com/celo-org/self/pull/170 because we didn't have the instance, so please make sure you add it back to https://github.com/celo-org/self/pull/170