### PR TITLE
Investigating proofReset and cleanSelfApp

### DIFF
--- a/app/src/screens/Onboarding/LoadingScreen.tsx
+++ b/app/src/screens/Onboarding/LoadingScreen.tsx
@@ -36,8 +36,7 @@ const LoadingScreen: React.FC<LoadingScreenProps> = ({}) => {
     }, 3000);
   };
   const [animationSource, setAnimationSource] = useState<any>(miscAnimation);
-  const { registrationStatus, resetProof } =
-    useProofInfo();
+  const { registrationStatus, resetProof } = useProofInfo();
   const { getPassportDataAndSecret, clearPassportData } = usePassport();
 
   useEffect(() => {

--- a/app/src/screens/Onboarding/LoadingScreen.tsx
+++ b/app/src/screens/Onboarding/LoadingScreen.tsx
@@ -41,6 +41,7 @@ const LoadingScreen: React.FC<LoadingScreenProps> = ({}) => {
   const { getPassportDataAndSecret, clearPassportData } = usePassport();
 
   useEffect(() => {
+    // TODO this makes sense if reset proof was only about passport registration
     resetProof();
   }, []);
 

--- a/app/src/screens/ProveFlow/ProveScreen.tsx
+++ b/app/src/screens/ProveFlow/ProveScreen.tsx
@@ -84,7 +84,7 @@ const ProveScreen: React.FC = () => {
 
   const onVerify = useCallback(
     async function () {
-      resetProof();
+      resetProof(); // this make zero sense we are removing all reference to the app so we wont be able to get its name on the results scree
       buttonTap();
       if (isProcessingRef.current) {
         return;

--- a/app/src/screens/ProveFlow/ProveScreen.tsx
+++ b/app/src/screens/ProveFlow/ProveScreen.tsx
@@ -40,7 +40,7 @@ import {
 const ProveScreen: React.FC = () => {
   const { navigate } = useNavigation();
   const { getPassportDataAndSecret } = usePassport();
-  const { selectedApp, resetProof } = useProofInfo();
+  const { selectedApp } = useProofInfo();
   const { handleProofVerified } = useApp();
   const selectedAppRef = useRef(selectedApp);
 
@@ -139,7 +139,7 @@ const ProveScreen: React.FC = () => {
         isProcessingRef.current = false;
       }
     },
-    [navigate, getPassportDataAndSecret, handleProofVerified, resetProof],
+    [navigate, getPassportDataAndSecret, handleProofVerified],
   );
 
   async function sendMockPayload() {

--- a/app/src/screens/ProveFlow/ProveScreen.tsx
+++ b/app/src/screens/ProveFlow/ProveScreen.tsx
@@ -84,7 +84,6 @@ const ProveScreen: React.FC = () => {
 
   const onVerify = useCallback(
     async function () {
-      resetProof(); // this make zero sense we are removing all reference to the app so we wont be able to get its name on the results scree
       buttonTap();
       if (isProcessingRef.current) {
         return;

--- a/app/src/screens/ProveFlow/ViewFinder.tsx
+++ b/app/src/screens/ProveFlow/ViewFinder.tsx
@@ -73,6 +73,7 @@ const QRCodeViewFinderScreen: React.FC<QRCodeViewFinderScreenProps> = ({}) => {
           return;
         }
 
+        // TODO (_): cleaning here makes sense, clean app should set the disclosure states to default too
         // Clean up first
         cleanSelfApp();
 

--- a/app/src/stores/proofProvider.tsx
+++ b/app/src/stores/proofProvider.tsx
@@ -83,6 +83,8 @@ export function ProofProvider({ children }: PropsWithChildren<{}>) {
     setSelectedAppInternal(defaults.selectedApp);
   }, []);
 
+  // why do we have both resetProof and cleanSelfApp?
+  // possible we can make resetProof only about registration status, and clean app about disclosures status
   const resetProof = useCallback(() => {
     setRegistrationStatus(ProofStatusEnum.PENDING);
     setDisclosureStatus(ProofStatusEnum.PENDING);

--- a/app/src/stores/userStore.ts
+++ b/app/src/stores/userStore.ts
@@ -1,4 +1,3 @@
-
 import { DEFAULT_DOB, DEFAULT_DOE, DEFAULT_PNUMBER } from '@env';
 import { create } from 'zustand';
 


### PR DESCRIPTION
Started this morning looking at the proofProvider to start to think about the activity/history but ended up diving into some odd things.

## some history

i originally made the ProofProvider because I wanted to move the websocket stuff out of the screen so multiple screens could listen. that websocket setup and listening has been moved to the appProvider. 

## proof Provider now holds state for 
* the app (aka the website) that is currently requesting a proof disclosure, 
* the items of the disclosure, 
* the status of the disclosure 
* the status of passport registration 

one of these things doesnt quiet fit but not the worst thing. 


## `cleanSelfApp` and `resetProof`

these are both methods on the proofProvider 

they both would set selectedApp back to defaults (although clean app would have properties whereas resetProof would be empty object. 


`cleanSelfApp` is only called when opening the QRcode screen (makes sense!) 

`resetProof` is called in a few places sometimes i think with the intention of reseting just the registration status others with intention of resetting the app and others i really dont think are correct 



<img width="734" alt="Screenshot 2025-02-21 at 12 20 20 PM" src="https://github.com/user-
attachments/assets/36410ad0-7a44-49cf-8d4b-9f04c4769000" />
<img width="460" alt="Screenshot 2025-02-21 at 12 20 55 PM" src="https://github.com/user-attachments/assets/eff44696-0e2c-4180-96bd-b986b958ebf3" />
