### PR TITLE
Fix playground

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -85,8 +85,8 @@ android {
         applicationId "com.proofofpassportapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 35
-        versionName "2.4.4"
+        versionCode 37
+        versionName "2.4.6"
         externalNativeBuild {
             cmake {
                 cppFlags += "-fexceptions -frtti -std=c++11"

--- a/app/ios/Self.xcodeproj/project.pbxproj
+++ b/app/ios/Self.xcodeproj/project.pbxproj
@@ -836,7 +836,10 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -926,7 +929,10 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = false;

--- a/app/ios/Self.xcodeproj/project.pbxproj
+++ b/app/ios/Self.xcodeproj/project.pbxproj
@@ -481,7 +481,7 @@
 				CODE_SIGN_ENTITLEMENTS = OpenPassport/OpenPassportDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 97;
+				CURRENT_PROJECT_VERSION = 98;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 5B29R5LYHQ;
 				ENABLE_BITCODE = NO;
@@ -596,7 +596,7 @@
 					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/MoproKit/Libs",
 				);
-				MARKETING_VERSION = 2.4.5;
+				MARKETING_VERSION = 2.4.6;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -619,7 +619,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = OpenPassport/OpenPassport.entitlements;
-				CURRENT_PROJECT_VERSION = 97;
+				CURRENT_PROJECT_VERSION = 98;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 5B29R5LYHQ;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -733,7 +733,7 @@
 					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/MoproKit/Libs",
 				);
-				MARKETING_VERSION = 2.4.5;
+				MARKETING_VERSION = 2.4.6;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -836,10 +836,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -929,10 +926,7 @@
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = false;

--- a/app/src/components/Disclosures.tsx
+++ b/app/src/components/Disclosures.tsx
@@ -43,9 +43,10 @@ export default function Disclosures({ disclosures }: DisclosureProps) {
     <YStack>
       {ORDERED_KEYS.map(key => {
         const isEnabled = disclosures[key];
-        if (!isEnabled) {
+        if (!isEnabled || (Array.isArray(isEnabled) && isEnabled.length === 0)) {
           return null;
         }
+        
 
         let text = '';
         switch (key) {

--- a/app/src/components/Disclosures.tsx
+++ b/app/src/components/Disclosures.tsx
@@ -43,10 +43,12 @@ export default function Disclosures({ disclosures }: DisclosureProps) {
     <YStack>
       {ORDERED_KEYS.map(key => {
         const isEnabled = disclosures[key];
-        if (!isEnabled || (Array.isArray(isEnabled) && isEnabled.length === 0)) {
+        if (
+          !isEnabled ||
+          (Array.isArray(isEnabled) && isEnabled.length === 0)
+        ) {
           return null;
         }
-        
 
         let text = '';
         switch (key) {

--- a/app/src/screens/AccountFlow/AccountRecoveryChoiceScreen.tsx
+++ b/app/src/screens/AccountFlow/AccountRecoveryChoiceScreen.tsx
@@ -63,7 +63,7 @@ const AccountRecoveryChoiceScreen: React.FC<
           <Title>Restore your Self account</Title>
           <Description>
             By continuing, you certify that this passport belongs to you and is
-            not stolen or forged. {' '}
+            not stolen or forged.{' '}
             {biometricsAvailable && (
               <>
                 Your device doesn't support biometrics or is disabled for apps

--- a/app/src/screens/AccountFlow/AccountRecoveryChoiceScreen.tsx
+++ b/app/src/screens/AccountFlow/AccountRecoveryChoiceScreen.tsx
@@ -63,7 +63,7 @@ const AccountRecoveryChoiceScreen: React.FC<
           <Title>Restore your Self account</Title>
           <Description>
             By continuing, you certify that this passport belongs to you and is
-            not stolen or forged. 
+            not stolen or forged. {' '}
             {biometricsAvailable && (
               <>
                 Your device doesn't support biometrics or is disabled for apps

--- a/app/src/screens/AccountFlow/AccountRecoveryChoiceScreen.tsx
+++ b/app/src/screens/AccountFlow/AccountRecoveryChoiceScreen.tsx
@@ -63,7 +63,7 @@ const AccountRecoveryChoiceScreen: React.FC<
           <Title>Restore your Self account</Title>
           <Description>
             By continuing, you certify that this passport belongs to you and is
-            not stolen or forged.
+            not stolen or forged. 
             {biometricsAvailable && (
               <>
                 Your device doesn't support biometrics or is disabled for apps

--- a/app/src/screens/AccountFlow/RecoverWithPhraseScreen.tsx
+++ b/app/src/screens/AccountFlow/RecoverWithPhraseScreen.tsx
@@ -18,6 +18,8 @@ import {
   slate700,
   white,
 } from '../../utils/colors';
+import { loadPassportDataAndSecret } from '../../stores/passportDataProvider';
+import { isUserRegistered } from '../../utils/proving/payload';
 
 interface RecoverWithPhraseScreenProps {}
 
@@ -48,10 +50,22 @@ const RecoverWithPhraseScreen: React.FC<
 
     if (!result) {
       console.warn('Failed to restore account');
-      // TODO SOMETHING ELSE?
+      navigation.navigate('Launch');
       setRestoring(false);
       return;
     }
+
+    const passportDataAndSecret = (await loadPassportDataAndSecret()) as string;
+    const { passportData, secret } = JSON.parse(passportDataAndSecret);
+    const isRegistered = await isUserRegistered(passportData, secret);
+    console.log('User is registered:', isRegistered);
+    if (!isRegistered) {
+      console.log('Secret provided did not match a registered passport. Please try again.');
+      navigation.navigate('Launch');
+      setRestoring(false);
+      return;
+    }
+
     setRestoring(false);
     navigation.navigate('AccountVerifiedSuccess');
   }, [mnemonic, restoreAccountFromMnemonic]);

--- a/app/src/screens/AccountFlow/RecoverWithPhraseScreen.tsx
+++ b/app/src/screens/AccountFlow/RecoverWithPhraseScreen.tsx
@@ -10,6 +10,7 @@ import { SecondaryButton } from '../../components/buttons/SecondaryButton';
 import Description from '../../components/typography/Description';
 import Paste from '../../images/icons/paste.svg';
 import { useAuth } from '../../stores/authProvider';
+import { loadPassportDataAndSecret } from '../../stores/passportDataProvider';
 import {
   black,
   slate300,
@@ -18,7 +19,6 @@ import {
   slate700,
   white,
 } from '../../utils/colors';
-import { loadPassportDataAndSecret } from '../../stores/passportDataProvider';
 import { isUserRegistered } from '../../utils/proving/payload';
 
 interface RecoverWithPhraseScreenProps {}
@@ -60,7 +60,9 @@ const RecoverWithPhraseScreen: React.FC<
     const isRegistered = await isUserRegistered(passportData, secret);
     console.log('User is registered:', isRegistered);
     if (!isRegistered) {
-      console.log('Secret provided did not match a registered passport. Please try again.');
+      console.log(
+        'Secret provided did not match a registered passport. Please try again.',
+      );
       navigation.navigate('Launch');
       setRestoring(false);
       return;

--- a/app/src/screens/Onboarding/LoadingScreen.tsx
+++ b/app/src/screens/Onboarding/LoadingScreen.tsx
@@ -24,7 +24,7 @@ type LoadingScreenProps = StaticScreenProps<{}>;
 
 const LoadingScreen: React.FC<LoadingScreenProps> = ({}) => {
   const goToSuccessScreen = useHapticNavigation('AccountVerifiedSuccess');
-  const goToErrorScreen = useHapticNavigation('ConfirmBelongingScreen');
+  const goToErrorScreen = useHapticNavigation('Launch');
   const goToUnsupportedScreen = useHapticNavigation('UnsupportedPassport');
   const navigation = useNavigation();
 

--- a/app/src/screens/ProveFlow/ProofRequestStatusScreen.tsx
+++ b/app/src/screens/ProveFlow/ProofRequestStatusScreen.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { StatusBar, StyleSheet, View } from 'react-native';
 
 import LottieView from 'lottie-react-native';
+import { Spinner } from 'tamagui';
 
 import loadingAnimation from '../../assets/animations/loading/misc.json';
 import failAnimation from '../../assets/animations/proof_failed.json';
@@ -64,13 +65,16 @@ const SuccessScreen: React.FC = () => {
       >
         <View style={styles.content}>
           <Title size="large">{getTitle(disclosureStatus)}</Title>
-          <Info status={disclosureStatus} appName={appName} />
+          <Info
+            status={disclosureStatus}
+            appName={appName === '' ? 'The app' : appName}
+          />
         </View>
         <PrimaryButton
           disabled={disclosureStatus === 'pending'}
           onPress={onOkPress}
         >
-          OK
+          {disclosureStatus === 'pending' ? <Spinner /> : 'OK'}
         </PrimaryButton>
       </ExpandableBottomLayout.BottomSection>
     </ExpandableBottomLayout.Layout>

--- a/app/src/screens/ProveFlow/ProveScreen.tsx
+++ b/app/src/screens/ProveFlow/ProveScreen.tsx
@@ -44,6 +44,7 @@ const ProveScreen: React.FC = () => {
   const { selectedApp, resetProof, cleanSelfApp } = useProofInfo();
   const { handleProofVerified } = useApp();
   const selectedAppRef = useRef(selectedApp);
+  const isProcessing = useRef(false);
 
   const [hasScrolledToBottom, setHasScrolledToBottom] = useState(false);
   const [scrollViewContentHeight, setScrollViewContentHeight] = useState(0);
@@ -106,11 +107,16 @@ const ProveScreen: React.FC = () => {
 
   const onVerify = useCallback(
     async function () {
+      if (isProcessing.current) return;
+      isProcessing.current = true;
+
       resetProof();
       buttonTap();
       const currentApp = selectedAppRef.current;
+
       try {
         let timeToNavigateToStatusScreen: NodeJS.Timeout;
+
         const passportDataAndSecret = await getPassportDataAndSecret().catch(
           (e: Error) => {
             console.error('Error getPassportDataAndSecret', e);
@@ -133,6 +139,7 @@ const ProveScreen: React.FC = () => {
         const { passportData, secret } = passportDataAndSecret.data;
         const isRegistered = await isUserRegistered(passportData, secret);
         console.log('isRegistered', isRegistered);
+
         if (!isRegistered) {
           clearTimeout(timeToNavigateToStatusScreen);
           console.log(
@@ -157,6 +164,8 @@ const ProveScreen: React.FC = () => {
       } catch (e) {
         console.log('Error sending VC and disclose payload', e);
         globalSetDisclosureStatus?.(ProofStatusEnum.ERROR);
+      } finally {
+        isProcessing.current = false;
       }
     },
     [navigate, getPassportDataAndSecret, handleProofVerified, resetProof],

--- a/app/src/screens/ProveFlow/ProveScreen.tsx
+++ b/app/src/screens/ProveFlow/ProveScreen.tsx
@@ -107,7 +107,9 @@ const ProveScreen: React.FC = () => {
 
   const onVerify = useCallback(
     async function () {
-      if (isProcessing.current) return;
+      if (isProcessing.current) {
+        return;
+      }
       isProcessing.current = true;
 
       resetProof();

--- a/app/src/stores/appProvider.tsx
+++ b/app/src/stores/appProvider.tsx
@@ -47,6 +47,7 @@ const initSocket = (sessionId: string) => {
   const socket = io(socketUrl, {
     path: '/',
     transports: ['websocket'],
+    forceNew: true,
     query: {
       sessionId,
       clientType: 'mobile',

--- a/app/src/utils/proving/tee.ts
+++ b/app/src/utils/proving/tee.ts
@@ -161,6 +161,9 @@ export async function sendPayload(
           console.log('Truncated submit body:', truncatedBody);
           ws.send(JSON.stringify(submitBody));
         } else {
+          if (result.error) {
+            finalize(ProofStatusEnum.ERROR);
+          }
           const receivedUuid = result.result;
           console.log('Received UUID:', receivedUuid);
           console.log(result);

--- a/app/src/utils/proving/tee.ts
+++ b/app/src/utils/proving/tee.ts
@@ -180,7 +180,14 @@ export async function sendPayload(
               const data =
                 typeof message === 'string' ? JSON.parse(message) : message;
               console.log('SocketIO message:', data);
-              if (data.status === 4) {
+              if (data.status === 3) {
+                console.log('Failed to generate proof');
+                socket?.disconnect();
+                if (ws.readyState === WebSocket.OPEN) {
+                  ws.close();
+                }
+                finalize(ProofStatusEnum.FAILURE);
+              } else if (data.status === 4) {
                 console.log('Proof verified');
                 socket?.disconnect();
                 if (ws.readyState === WebSocket.OPEN) {


### PR DESCRIPTION
- fix onVerify being called twice when reading a QR code.
- Bump version for new internal release.
- When circuit name not found on TEE side (circuit not deployed but that was not caught when checking for signature algorithm support), show failure instead of stalling.
- When fails to register, goes back to HomeScreen instead of going back to ConfirmBelongingScreen, which shows a positive visual signal, which is confusing.
- Many small fixed on disclosure screen